### PR TITLE
Force colors when running `composer test`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         }
     },
     "scripts": {
-        "test": "vendor/bin/phpunit",
+        "test": "vendor/bin/phpunit --colors=always",
         "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
 
     },


### PR DESCRIPTION
When running `composer test` it does not use coloring, even though `phpunit.xml.dist` has `colors` set to `true`.

_(Sidenote: using the default macOS `Terminal.app` here, with [a custom prompt](https://github.com/bramus/freshinstall/blob/master/resources/dotfiles/.bash_prompt))_

This PR adjusts the `composer test` script so that it enforces the use of colors wit PHPUnit.

Here's the result (before and after):

![screenshot 2019-02-19 at 09 37 01](https://user-images.githubusercontent.com/213073/53001169-53c1ee80-342a-11e9-998e-534bdf84ecf2.png)