### PR TITLE
add string[] to isOneOf() doc-tag

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -85,7 +85,7 @@ abstract class Enum implements JsonSerializable
     }
 
     /**
-     * @param \Spatie\Enum\Enum[] $enums
+     * @param string[]|\Spatie\Enum\Enum[] $enums
      *
      * @return bool
      */


### PR DESCRIPTION
`isOneOf()` uses `equals()` to compare and compatible with `string[]`