### PR TITLE
Laravel model support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `enum` will be documented in this file
 
+## 2.1.0 - 2019-04-??
+
+- Add Laravel model integration
+
 ## 2.0.0 - 2019-04-01
 
 A full major rework of the `Enum` class - we try to list all changes, for more details you can check out the [PR](https://github.com/spatie/enum/pull/18) and the [Issue](https://github.com/spatie/enum/issues/10).

--- a/README.md
+++ b/README.md
@@ -166,6 +166,70 @@ This package also supports these enum specific methods.
 
 By declaring the enum class itself as abstract, and using static constructors instead of doc comments, you're able to return an anonymous class per enum, each of them implementing the required methods.
 
+### Laravel support
+
+Chances are that if you're working in a Laravel project, you'll want to use enums within your models.
+This package provides a trait you can use in these models, 
+to allow allow automatic casting between stored enum values and enum objects. 
+
+```php
+use Spatie\Enum\HasEnums;
+
+final class TestModel extends Model
+{
+    use HasEnums;
+
+    protected $enums = [
+        'status' => TestModelStatus::class,
+    ];
+}
+```
+
+By using the `HasEnums` trait, you'll be able to work with the `status` field like so:
+
+```php
+$model = TestModel::create([
+    'status' => StatusEnum::DRAFT(),
+]);
+
+// …
+
+$model->status = StatusEnum::PUBLISHED();
+
+// …
+
+$model->status->isEqual(StatusEnum::ARCHIVED());
+``` 
+
+In some cases, enums can be stored differently in the database. 
+Take for example a legacy application.
+
+By using the `HasEnums` trait, you can provide a mapping on your enum classes:
+
+```php
+/**
+ * @method static self DRAFT()
+ * @method static self PUBLISHED()
+ * @method static self ARCHIVED()
+ */
+final class StatusEnum extends Enum
+{
+    public static $map = [
+        'archived' => 'legacy archived value',
+    ];
+}
+```
+
+Once a mapping is provided and the trait is used in your model, 
+the package will automatically handle it for you.
+
+#### Further Laravel integration:
+
+There are some more Laravel things we'll be adding in the future.
+
+- [ ] Allow the mapping to also be defined as a function, resulting in even more flexibility.
+- [ ] Add `whereEnum('field', Enum $enum)` scope, which will also take the mapping into account.
+
 ### Testing
 
 ``` bash

--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,11 @@
     ],
     "require": {
         "php": "^7.2",
-        "ext-json": "*"
+        "ext-json": "*",
+        "orchestra/testbench": "^3.8"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "^7.0",
         "symfony/stopwatch": "^4.2"
     },
     "autoload": {

--- a/src/Exceptions/InvalidEnumError.php
+++ b/src/Exceptions/InvalidEnumError.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\Enum\Exceptions;
+
+use TypeError;
+
+final class InvalidEnumError extends TypeError
+{
+    public static function make(
+        string $class,
+        string $field,
+        string $expected,
+        string $got
+    ): InvalidEnumError {
+        return new self("Expected {$class}::{$field} to be instance of {$expected}, instead got {$got}");
+    }
+}

--- a/src/HasEnums.php
+++ b/src/HasEnums.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Spatie\Enum;
+
+use Spatie\Enum\Exceptions\InvalidEnumError;
+use Spatie\Enum\Exceptions\InvalidValueException;
+
+trait HasEnums
+{
+    /**
+     * @param $key
+     * @param \Spatie\Enum\Enum $enumObject
+     *
+     * @return mixed
+     */
+    public function setAttribute($key, $enumObject)
+    {
+        if (! isset($this->enums[$key])) {
+            return parent::setAttribute($key, $enumObject);
+        }
+
+        $enumClass = $this->enums[$key];
+
+        if (! is_a($enumObject, $enumClass)) {
+            throw InvalidEnumError::make(
+                static::class,
+                $key,
+                $enumClass,
+                get_class($enumObject)
+            );
+        }
+
+        $enumValue = $enumObject->getValue();
+
+        $mappedValue = $enumClass::$map[$enumValue] ?? null;
+
+        $this->attributes[$key] = $mappedValue ?? $enumValue;
+
+        return $this;
+    }
+
+    public function getAttribute($key)
+    {
+        if (! isset($this->enums[$key])) {
+            return parent::getAttribute($key);
+        }
+
+        $enumClass = $this->enums[$key];
+
+        $storedEnumValue = $this->attributes[$key] ?? null;
+
+        try {
+            $enumObject = forward_static_call_array(
+                $enumClass . '::make',
+                [$storedEnumValue]
+            );
+        } catch (InvalidValueException $exception) {
+            $mappedEnumValue = array_search($storedEnumValue, $enumClass::$map ?? []);
+
+            if (! $mappedEnumValue) {
+                throw new InvalidValueException($storedEnumValue, $enumClass);
+            }
+
+            $enumObject = forward_static_call_array(
+                $enumClass . '::make',
+                [$mappedEnumValue]
+            );
+        }
+
+        return $enumObject;
+    }
+}

--- a/tests/Laravel/LaravelTestCase.php
+++ b/tests/Laravel/LaravelTestCase.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Spatie\Enum\Tests\Laravel;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Orchestra\Testbench\TestCase;
+
+abstract class LaravelTestCase extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpDatabase();
+    }
+
+    protected function setUpDatabase()
+    {
+        Schema::create('test', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('status');
+            $table->timestamps();
+        });
+    }
+
+    public function getEnvironmentSetUp($app)
+    {
+        config()->set('database.default', 'sqlite');
+
+        config()->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+}

--- a/tests/Laravel/ModelEnumTest.php
+++ b/tests/Laravel/ModelEnumTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Spatie\Enum\Tests\Laravel;
+
+use Spatie\Enum\Exceptions\InvalidEnumError;
+use stdClass;
+
+final class ModelEnumTest extends LaravelTestCase
+{
+    /** @test */
+    public function it_saves_the_value_of_an_enum()
+    {
+        $model = TestModel::create([
+            'status' => TestModelStatus::draft(),
+        ]);
+
+        $model->refresh();
+
+        $this->assertTrue($model->status->isEqual(TestModelStatus::draft()));
+    }
+
+    /** @test */
+    public function an_invalid_class_throws_an_error()
+    {
+        $this->expectException(InvalidEnumError::class);
+
+        TestModel::create([
+            'status' => new stdClass(),
+        ]);
+    }
+
+    /** @test */
+    public function an_enum_value_can_be_mapped()
+    {
+        $model = TestModel::create([
+            'status' => TestModelStatus::archived(),
+        ]);
+
+        $this->assertEquals(
+            TestModelStatus::$map['archived'],
+            $model->getAttributes()['status']
+        );
+
+        $model->refresh();
+
+        $this->assertTrue($model->status->isEqual(TestModelStatus::archived()));
+    }
+}

--- a/tests/Laravel/TestModel.php
+++ b/tests/Laravel/TestModel.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Spatie\Enum\Tests\Laravel;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\Enum\HasEnums;
+
+/**
+ * @property \Spatie\Enum\Tests\Laravel\TestModelStatus status
+ *
+ * @method static self create(array $properties)
+ */
+final class TestModel extends Model
+{
+    use HasEnums;
+
+    protected $enums = [
+        'status' => TestModelStatus::class,
+    ];
+
+    protected $guarded = [];
+
+    protected $table = 'test';
+}

--- a/tests/Laravel/TestModelStatus.php
+++ b/tests/Laravel/TestModelStatus.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\Enum\Tests\Laravel;
+
+use Spatie\Enum\Enum;
+
+/**
+ * @method static self draft()
+ * @method static self published()
+ * @method static self archived()
+ */
+final class TestModelStatus extends Enum
+{
+    public static $map = [
+        'archived' => 'stored archive',
+    ];
+}


### PR DESCRIPTION
We decided we wanted to add this functionality in this package, instead of providing a whole separate one. 

It allows for easy model integration, like so:

```php
use Spatie\Enum\HasEnums;

final class TestModel extends Model
{
    use HasEnums;

    protected $enums = [
        'status' => TestModelStatus::class,
    ];
}
```

```php
$model = TestModel::create([
    'status' => StatusEnum::DRAFT(),
]);

// …

$model->status = StatusEnum::PUBLISHED();

// …

$model->status->isEqual(StatusEnum::ARCHIVED());
``` 