### PR TITLE
Fix calling public non-static methods

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -291,6 +291,7 @@ abstract class Enum implements Enumerable, JsonSerializable
         foreach ($reflection->getMethods(ReflectionMethod::IS_STATIC | ReflectionMethod::IS_PUBLIC) as $method) {
             if (
                 $method->getDeclaringClass()->getName() === self::class
+                || ! ($method->isPublic() && $method->isStatic())
                 || in_array($method->getName(), $selfMethods)
             ) {
                 continue;

--- a/tests/BoolEnumTest.php
+++ b/tests/BoolEnumTest.php
@@ -286,4 +286,10 @@ class BoolEnumTest extends TestCase
 
         BoolEnum::isFalse(2);
     }
+
+    /** @test */
+    public function can_call_public_nonstatic_method()
+    {
+        $this->assertTrue(BoolEnum::true()->testMethod());
+    }
 }

--- a/tests/Enums/BoolEnum.php
+++ b/tests/Enums/BoolEnum.php
@@ -13,4 +13,8 @@ use Spatie\Enum\Enum;
  */
 final class BoolEnum extends Enum
 {
+    public function testMethod()
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
See #31

Note that using `ReflectionMethod::IS_STATIC & ReflectionMethod::IS_PUBLIC` will not work as noted in the PHP docs:

> Note that other bitwise operations, for instance ~ will not work as expected.
> — https://www.php.net/manual/de/reflectionclass.getmethods.php