### PR TITLE
Add getAll method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "ext-json": "*"
     },
     "require-dev": {
+        "larapack/dd": "^1.1",
         "phpunit/phpunit": "^8.0",
         "symfony/stopwatch": "^4.2"
     },

--- a/docs/usage/make-enum.md
+++ b/docs/usage/make-enum.md
@@ -21,3 +21,9 @@ $monday = WeekDayEnum::make('Montag');
 ```php
 $monday = WeekDayEnum::make(1);
 ```
+
+## Get all
+
+```php
+WeekDayEnum::all(); // returns an array of `WeekDayEnum` instances
+```

--- a/docs/usage/make-enum.md
+++ b/docs/usage/make-enum.md
@@ -25,5 +25,5 @@ $monday = WeekDayEnum::make(1);
 ## Get all
 
 ```php
-WeekDayEnum::all(); // returns an array of `WeekDayEnum` instances
+WeekDayEnum::getAll(); // returns an array of `WeekDayEnum` instances
 ```

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -193,9 +193,9 @@ abstract class Enum implements Enumerable, JsonSerializable
      */
     public static function getAll(): array
     {
-        return array_map(function(string $name) {
-            return static::$name();
-        }, static::getNames());
+        return array_map(function(string $value) {
+            return static::make($value);
+        }, static::getValues());
     }
 
     protected static function isValidIndex(int $index): bool

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -188,7 +188,7 @@ abstract class Enum implements Enumerable, JsonSerializable
         return array_combine(static::getValues(), static::getIndices());
     }
 
-    public static function all(): array
+    public static function getAll(): array
     {
         return array_map(function(string $name) {
             return static::$name();

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -188,6 +188,9 @@ abstract class Enum implements Enumerable, JsonSerializable
         return array_combine(static::getValues(), static::getIndices());
     }
 
+    /**
+     * @return Enumerable[]
+     */
     public static function getAll(): array
     {
         return array_map(function(string $name) {

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -188,6 +188,13 @@ abstract class Enum implements Enumerable, JsonSerializable
         return array_combine(static::getValues(), static::getIndices());
     }
 
+    public static function all(): array
+    {
+        return array_map(function(string $name) {
+            return static::$name();
+        }, static::getNames());
+    }
+
     protected static function isValidIndex(int $index): bool
     {
         return in_array($index, static::getIndices(), true);

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -189,7 +189,7 @@ abstract class Enum implements Enumerable, JsonSerializable
     }
 
     /**
-     * @return Enumerable[]
+     * @return \Spatie\Enum\Enumerable[]
      */
     public static function getAll(): array
     {

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -193,7 +193,7 @@ abstract class Enum implements Enumerable, JsonSerializable
      */
     public static function getAll(): array
     {
-        return array_map(function(int $index) {
+        return array_map(function (int $index) {
             return static::make($index);
         }, static::getIndices());
     }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -193,9 +193,9 @@ abstract class Enum implements Enumerable, JsonSerializable
      */
     public static function getAll(): array
     {
-        return array_map(function(string $value) {
-            return static::make($value);
-        }, static::getValues());
+        return array_map(function(int $index) {
+            return static::make($index);
+        }, static::getIndices());
     }
 
     protected static function isValidIndex(int $index): bool

--- a/src/Enumerable.php
+++ b/src/Enumerable.php
@@ -40,6 +40,13 @@ interface Enumerable
     public static function getValues(): array;
 
     /**
+     * Get all enumerables as array
+     *
+     * @return \Spatie\Enum\Enumerable[]
+     */
+    public static function getAll(): array;
+
+    /**
      * Get the current name.
      *
      * @return string

--- a/src/Enumerable.php
+++ b/src/Enumerable.php
@@ -40,7 +40,7 @@ interface Enumerable
     public static function getValues(): array;
 
     /**
-     * Get all enumerables as array
+     * Get all enumerables as array.
      *
      * @return \Spatie\Enum\Enumerable[]
      */

--- a/tests/BoolEnumTest.php
+++ b/tests/BoolEnumTest.php
@@ -15,6 +15,21 @@ use Spatie\Enum\Exceptions\InvalidValueException;
 class BoolEnumTest extends TestCase
 {
     /** @test */
+    public function it_can_get_all_instances()
+    {
+        $enums = BoolEnum::all();
+
+        $this->assertCount(2, $enums);
+
+        foreach($enums as $enum) {
+            $this->assertInstanceOf(BoolEnum::class, $enum);
+        }
+
+        $this->assertEquals('false', $enums[0]->getValue());
+        $this->assertEquals('true', $enums[1]->getValue());
+    }
+
+    /** @test */
     public function can_create_true_instance_from_doc_tag_name()
     {
         $true = BoolEnum::true();

--- a/tests/BoolEnumTest.php
+++ b/tests/BoolEnumTest.php
@@ -17,7 +17,7 @@ class BoolEnumTest extends TestCase
     /** @test */
     public function it_can_get_all_instances()
     {
-        $enums = BoolEnum::all();
+        $enums = BoolEnum::getAll();
 
         $this->assertCount(2, $enums);
 

--- a/tests/BoolEnumTest.php
+++ b/tests/BoolEnumTest.php
@@ -21,7 +21,7 @@ class BoolEnumTest extends TestCase
 
         $this->assertCount(2, $enums);
 
-        foreach($enums as $enum) {
+        foreach ($enums as $enum) {
             $this->assertInstanceOf(BoolEnum::class, $enum);
         }
 


### PR DESCRIPTION
Adds an `all` method.

We probably need to create a new major version for this as this will break for people that use an enum with a value of `all`.