### PR TITLE
make isValid checks public

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -198,17 +198,17 @@ abstract class Enum implements Enumerable, JsonSerializable
         }, static::getIndices());
     }
 
-    protected static function isValidIndex(int $index): bool
+    public static function isValidIndex(int $index): bool
     {
         return in_array($index, static::getIndices(), true);
     }
 
-    protected static function isValidName(string $value): bool
+    public static function isValidName(string $value): bool
     {
         return in_array(strtoupper($value), static::getNames(), true);
     }
 
-    protected static function isValidValue(string $value): bool
+    public static function isValidValue(string $value): bool
     {
         return in_array($value, static::getValues(), true);
     }

--- a/src/Enumerable.php
+++ b/src/Enumerable.php
@@ -94,4 +94,31 @@ interface Enumerable
      * @return array
      */
     public static function toArray(): array;
+
+    /**
+     * Check if the given index is a valid one.
+     *
+     * @param int $index
+     *
+     * @return bool
+     */
+    public static function isValidIndex(int $index): bool;
+
+    /**
+     * Check if the given name is a valid one.
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    public static function isValidName(string $name): bool;
+
+    /**
+     * Check if the given value is a valid one.
+     *
+     * @param string $value
+     *
+     * @return bool
+     */
+    public static function isValidValue(string $value): bool;
 }

--- a/tests/WeekDayEnumTest.php
+++ b/tests/WeekDayEnumTest.php
@@ -115,6 +115,27 @@ class WeekDayEnumTest extends TestCase
 
         canNotResolveFromAnonymousClassWithoutSurroundingMethod();
     }
+
+    /** @test */
+    public function can_check_if_index_is_valid()
+    {
+        $this->assertTrue(WeekDayEnum::isValidIndex(4));
+        $this->assertFalse(WeekDayEnum::isValidIndex(13));
+    }
+
+    /** @test */
+    public function can_check_if_name_is_valid()
+    {
+        $this->assertTrue(WeekDayEnum::isValidName('monday'));
+        $this->assertFalse(WeekDayEnum::isValidName('foobar'));
+    }
+
+    /** @test */
+    public function can_check_if_value_is_valid()
+    {
+        $this->assertTrue(WeekDayEnum::isValidValue('Freitag'));
+        $this->assertFalse(WeekDayEnum::isValidValue('FooBar'));
+    }
 }
 
 if (! function_exists('canNotResolveFromAnonymousClassWithoutSurroundingMethod')) {


### PR DESCRIPTION
This could be breaking for custom `Enumerable` implementations which have to re-implement the three methods.
But I don't think that this is a big issue and we could release this as a minor release.

This is a base for https://github.com/spatie/laravel-enum/issues/5 and also for some other cases where anyone wants to check if a value is a valid XYZ.