### PR TITLE
Allow passing invalid string values to isEqual

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -137,7 +137,11 @@ abstract class Enum implements Enumerable, JsonSerializable
     public function isEqual($value): bool
     {
         if (is_int($value) || is_string($value)) {
-            $value = static::make($value);
+            try {
+                $value = static::make($value);
+            } catch (InvalidValueException $error) {
+                return false;
+            }
         }
 
         if ($value instanceof $this) {

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -141,6 +141,8 @@ abstract class Enum implements Enumerable, JsonSerializable
                 $value = static::make($value);
             } catch (InvalidValueException $error) {
                 return false;
+            } catch (InvalidIndexException $error) {
+                return false;
             }
         }
 

--- a/tests/MonthEnumTest.php
+++ b/tests/MonthEnumTest.php
@@ -45,9 +45,11 @@ class MonthEnumTest extends TestCase
     {
         $this->assertTrue(MonthEnum::make(4)->isEqual(4));
         $this->assertFalse(MonthEnum::make(4)->isEqual(5));
+        $this->assertFalse(MonthEnum::make(4)->isEqual(-1));
 
         $this->assertTrue(MonthEnum::make(4)->isEqual('april'));
         $this->assertFalse(MonthEnum::make(4)->isEqual('may'));
+        $this->assertFalse(MonthEnum::make(4)->isEqual('invalid'));
 
         $this->assertTrue(MonthEnum::make(4)->isEqual(MonthEnum::april()));
         $this->assertFalse(MonthEnum::make(4)->isEqual(MonthEnum::may()));


### PR DESCRIPTION
Currently, passing a string value that doesn't exist as an enum value to `isEqual` throws an exception. Note that passing `null` will just return false.

I think it would be more handful if `isEqual` just returned false in that case.