### PR TITLE
Fix for static method call passed to `__call` within the context of an object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `enum` will be documented in this file
 
+## 2.3.2 - 2020-01-17
+
+- Fix for static method call passed to `__call` within the context of an object
+
 ## 2.3.1 - 2019-08-19
 
 - Fix `protected` method calls to allow overrides [#37](https://github.com/spatie/enum/pull/37)

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -62,10 +62,14 @@ abstract class Enum implements Enumerable, JsonSerializable
         $this->index = $index;
     }
 
-    public function __call(string $name, array $arguments): bool
+    public function __call(string $name, array $arguments)
     {
         if (static::startsWith($name, 'is')) {
             return $this->isEqual(substr($name, 2));
+        }
+
+        if (static::isValidName($name)) {
+            return static::make($name);
         }
 
         throw new BadMethodCallException('Call to undefined method '.static::class.'->'.$name.'()');

--- a/tests/EnumMethodTest.php
+++ b/tests/EnumMethodTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Spatie\Enum\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Spatie\Enum\Enum;
+
+class EnumMethodTest extends TestCase
+{
+    /** @test */
+    public function test()
+    {
+        $this->assertTrue(MyEnum::FOO()->isFoo());
+        $this->assertFalse(MyEnum::BAR()->isFoo());
+    }
+}
+
+
+/**
+ * @method static self FOO()
+ * @method static self BAR()
+ */
+class MyEnum extends Enum
+{
+    public function isFoo(): bool
+    {
+        return $this->isAny([
+            self::FOO()
+        ]);
+    }
+}


### PR DESCRIPTION
Apparently, if you call `static::FOO()` from within a method on that enum, that call would be passed to `__call` instead of `__callStatic`. I'm not quiet sure why yet… @Gummibeer do you have an idea?

I'll merge this quick fix for now, as this is a blocking issue in one of our projects, though maybe we can come up with a better solution.