### PR TITLE
fix the resolved name

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -377,7 +377,9 @@ abstract class Enum implements Enumerable, JsonSerializable
 
     protected static function resolveByName(string $name): array
     {
-        ['value' => $value, 'index' => $index] = static::resolve()[strtoupper($name)];
+        $name = strtoupper($name);
+
+        ['value' => $value, 'index' => $index] = static::resolve()[$name];
 
         return [$name, $index, $value];
     }

--- a/tests/BoolEnumTest.php
+++ b/tests/BoolEnumTest.php
@@ -43,6 +43,19 @@ class BoolEnumTest extends TestCase
     }
 
     /** @test */
+    public function can_create_true_instance_from_strange_name()
+    {
+        $true = BoolEnum::make('TrUe');
+
+        $this->assertInstanceOf(BoolEnum::class, $true);
+        $this->assertSame(1, $true->getIndex());
+        $this->assertTrue(boolval($true->getIndex()));
+        $this->assertSame('true', $true->getValue());
+        $this->assertEquals('true', $true);
+        $this->assertSame('TRUE', $true->getName());
+    }
+
+    /** @test */
     public function can_create_true_instance_from_index()
     {
         $true = BoolEnum::make(1);


### PR DESCRIPTION
Right now the input is used as the outputted `name`. But for all checks the `name` is uppercased. So the `name` should also be uppercased before it's put into the enum instance.