### PR TITLE
post v3 adjustments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,9 +45,9 @@
         }
     },
     "scripts": {
+        "psalm": "vendor/bin/psalm -c psalm.xml --show-info=true",
         "test": "vendor/bin/phpunit --colors=always",
-        "test-coverage": "vendor/bin/phpunit --coverage-html coverage",
-        "psalm": "vendor/bin/psalm -c psalm.xml --show-info=true"
+        "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
     },
     "support": {
         "issues": "https://github.com/spatie/enum/issues",

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
     },
     "scripts": {
         "test": "vendor/bin/phpunit --colors=always",
-        "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
+        "test-coverage": "vendor/bin/phpunit --coverage-html coverage",
+        "psalm": "vendor/bin/psalm -c psalm.xml --show-info=true"
     },
     "support": {
         "issues": "https://github.com/spatie/enum/issues",

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -175,9 +175,9 @@ abstract class Enum implements JsonSerializable
         $labelMap = static::labels();
 
         foreach ($matches[1] as $methodName) {
-            $value = $valueMap[$methodName] ?? $methodName;
+            $value = $valueMap[$methodName] = $valueMap[$methodName] ?? $methodName;
 
-            $label = $labelMap[$methodName] ?? $methodName;
+            $label = $labelMap[$methodName] = $labelMap[$methodName] ?? $methodName;
 
             $definition[$methodName] = new EnumDefinition($methodName, $value, $label);
         }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -203,7 +203,7 @@ abstract class Enum implements JsonSerializable
         return (string) $this->value;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return (string) $this->value;
     }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -92,7 +92,15 @@ abstract class Enum implements JsonSerializable
         return new static($name);
     }
 
-    public function __call($name, $arguments)
+    /**
+     * @param string $name
+     * @param array $arguments
+     *
+     * @return bool
+     *
+     * @throws UnknownEnumMethod
+     */
+    public function __call(string $name, array $arguments)
     {
         if (strpos($name, 'is') === 0) {
             $other = new static(substr($name, 2));

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -61,7 +61,14 @@ abstract class Enum implements JsonSerializable
         $this->label = $definition->label;
     }
 
-    public function __get($name)
+    /**
+     * @param string $name
+     *
+     * @return int|string
+     *
+     * @throws UnknownEnumProperty
+     */
+    public function __get(string $name)
     {
         if ($name === 'label') {
             return $this->label;

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -81,6 +81,12 @@ abstract class Enum implements JsonSerializable
         throw UnknownEnumProperty::new(static::class, $name);
     }
 
+    /**
+     * @param string $name
+     * @param array $arguments
+     *
+     * @return static
+     */
     public static function __callStatic(string $name, array $arguments)
     {
         return new static($name);

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -39,7 +39,7 @@ abstract class Enum implements JsonSerializable
      *
      * @return static
      */
-    public static function make($value)
+    public static function make($value): Enum
     {
         return new static($value);
     }

--- a/src/EnumDefinition.php
+++ b/src/EnumDefinition.php
@@ -3,7 +3,7 @@
 namespace Spatie\Enum;
 
 /** @internal */
-final class EnumDefinition
+class EnumDefinition
 {
     /** @var string|int */
     public $value;

--- a/src/EnumDefinition.php
+++ b/src/EnumDefinition.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\Enum;
 
-/**  @internal */
+/** @internal */
 final class EnumDefinition
 {
     /** @var string|int */

--- a/src/EnumDefinition.php
+++ b/src/EnumDefinition.php
@@ -24,13 +24,18 @@ final class EnumDefinition
         $this->label = $label;
     }
 
+    /**
+     * @param string|int $input
+     *
+     * @return bool
+     */
     public function equals($input): bool
     {
         if ($this->value === $input) {
             return true;
         }
 
-        if ($this->methodName === strtolower($input)) {
+        if (is_string($input) && $this->methodName === strtolower($input)) {
             return true;
         }
 

--- a/src/EnumDefinition.php
+++ b/src/EnumDefinition.php
@@ -2,7 +2,8 @@
 
 namespace Spatie\Enum;
 
-class EnumDefinition
+/**  @internal */
+final class EnumDefinition
 {
     /** @var string|int */
     public $value;


### PR DESCRIPTION
These are some adjustments/improvements regarding type-security and one to prevent all duplication conflicts.
Right now there's a way to get duplicated values/labels into the enum by using the same value as mapped value as another unmapped value has.

```php
/**
 * VALUE_1()
 * VALUE_2()
 */
class MyEnum {
  values = [
    'VALUE_1' => 'VALUE_2',
  ];
}
```

None of these changes should be breaking in any way. Most of them were already discussed with @brendt and because we both have the same goal: "strict type security" - they should be save to merge.