### PR TITLE
Don't cast value to string when serializing to JSON

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -207,9 +207,12 @@ abstract class Enum implements JsonSerializable
         return count($array) > count(array_unique($array));
     }
 
-    public function jsonSerialize(): string
+    /**
+     * @return int|string
+     */
+    public function jsonSerialize()
     {
-        return (string) $this->value;
+        return $this->value;
     }
 
     public function __toString(): string

--- a/tests/EnumValueTest.php
+++ b/tests/EnumValueTest.php
@@ -29,6 +29,13 @@ class EnumValueTest extends TestCase
 
         EnumWithDuplicatedValues::A();
     }
+
+    /** @test */
+    public function json_serialize_returns_same_value_type()
+    {
+        $this->assertSame(1, EnumWithValues::A()->jsonSerialize());
+        $this->assertSame('B', EnumWithValues::B()->jsonSerialize());
+    }
 }
 
 /**


### PR DESCRIPTION
Since Enum values can only be a string or integer, the extra string cast in `Enum::jsonSerialize` is unnecessary and unexpected.

```php
/**
 * @method static self draft()
 * @method static self published()
 * @method static self archived()
 */
class StatusEnum extends Enum
{
    protected static function values(): array
    {
        return [
            'draft' => 1,
            'published' => 2,
            'archived' => 3,
        ];
    }
}

var_dump(json_encode([
    'status' => StatusEnum::draft(),
]));

// string(14) "{"status":"1"}"
```

I was attempting to use this in an existing project where json encoded output is passed to javascript, and as a result strict checks for specific values are failing now that they are returning a string instead of an integer.

Technically a breaking change if anyone was already relying on this (IMO incorrect) behaviour since 3.0 was released.