### PR TITLE
PHPDoc: Add missing dollars for read-only properties

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -12,8 +12,8 @@ use Spatie\Enum\Exceptions\UnknownEnumProperty;
 use TypeError;
 
 /**
- * @property-read string|int value
- * @property-read string label
+ * @property-read string|int $value
+ * @property-read string $label
  *
  * @psalm-consistent-constructor
  */


### PR DESCRIPTION
PHPDoc for `Enum` class is missing dollars in front of variables and as result causes PHPStan static analyzer to fail for code that reads `label` and `value` properties.

## :books: Sources

- [@property-read examples in PHPDoc](https://docs.phpdoc.org/3.0/guide/references/phpdoc/tags/property-read.html)

## :microscope: Testing

1. Open PHPStan playground at https://phpstan.org/
2. Paste snippet below
3. The analyzer :x: fails.
4. Add the missing `$` in front of `label` variable in PHPDoc of the Enum class
5. The code :heavy_check_mark: passes.

```php
<?php declare(strict_types = 1);

/**
 * @property-read string label
 */
class Enum
{
	protected string $label;
}

/**
 * @method static self SOME_VALUE()
 */
class MyEnum extends Enum
{
}

function testFunction(): void
{
	$val = new MyEnum();
	$x = $val->label;
}
```