### PR TITLE
separate (extracting enum values from docs logic) in a method

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -202,11 +202,7 @@ abstract class Enum implements JsonSerializable
             return static::$definitionCache[$className];
         }
 
-        $reflectionClass = new ReflectionClass($className);
-
-        $docComment = $reflectionClass->getDocComment();
-
-        preg_match_all('/@method static self ([\w_]+)\(\)/', $docComment, $matches);
+        $matches = static::getDefinitionsFromClassDocs($className);
 
         $definition = [];
 
@@ -231,6 +227,17 @@ abstract class Enum implements JsonSerializable
         }
 
         return static::$definitionCache[$className] ??= $definition;
+    }
+
+    protected static function getDefinitionsFromClassDocs(string $className)
+    {
+        $reflectionClass = new ReflectionClass($className);
+
+        $docComment = $reflectionClass->getDocComment();
+
+        preg_match_all('/@method static self ([\w_]+)\(\)/', $docComment, $matches);
+
+        return $matches;
     }
 
     private static function arrayHasDuplicates(array $array): bool


### PR DESCRIPTION
I've a situation that I want to transform the values automatically from the definition to each corresponding title case
Ex:
```php
return [
    'SUPER_ADMIN' => 'Super Admin',
    'SYSTEM_USER' => 'System User',
];
```
when I added the `values` method and tried to call `toValues` method inside it an infinite recursion occurs because it calls `resolveDefinition` method which calls the `values` method again

I see that extracting the logic of getting definitions from class docs in a separate method will help what do you think?

the following image shows how I can use it to achieve my goal.
![image](https://user-images.githubusercontent.com/29691074/102819044-6f59ff80-43db-11eb-9551-70e64c084fde.png)
