### PR TITLE
remove extra whitespaces/tabs on docblock

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -204,7 +204,7 @@ abstract class Enum implements JsonSerializable
 
         $reflectionClass = new ReflectionClass($className);
 
-        $docComment = $reflectionClass->getDocComment();
+        $docComment = preg_replace('/\s+/', ' ', $reflectionClass->getDocComment());
 
         preg_match_all('/@method static self ([\w_]+)\(\)/', $docComment, $matches);
 

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -76,6 +76,12 @@ class EnumTest extends TestCase
 
         $this->assertTrue(EnumWithEnum::B()->equals($enum->test()));
     }
+
+    /** @test */
+    public function enum_docblock_whitespaces() {
+        $this->assertInstanceOf(BadDockBlockEnum::class, BadDockBlockEnum::A());
+        $this->assertInstanceOf(BadDockBlockEnum::class, BadDockBlockEnum::B());
+    }
 }
 
 /**
@@ -96,4 +102,12 @@ class EnumWithEnum extends Enum
     {
         return EnumWithEnum::B();
     }
+}
+
+/**
+ * @method  static  self       A()
+ * @method  static    self       B()
+ */
+class BadDockBlockEnum extends Enum {
+
 }


### PR DESCRIPTION
Hi! When I was working with enums, I noticed that the method would not work if there were extra spaces/tabs in the docblock. I tried to fix this.  (Sorry, typo in the test file, it should be 'doc' instead of 'dock'.)