### PR TITLE
Change @readonly annotation to @psalm-readonly

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -23,11 +23,11 @@ abstract class Enum implements JsonSerializable
 {
     /**
      * @var string|int
-     * @readonly
+     * @psalm-readonly
      */
     protected $value;
 
-    /** @readonly */
+    /** @psalm-readonly */
     protected string $label;
 
     /** @psalm-var array<string, array<string, \Spatie\Enum\EnumDefinition>> */


### PR DESCRIPTION
Hello,

Currently, using this package is incompatible with doctrine/annotations (and by extension jms-serializer) because of the `@readonly` annotation in Enum.php. This PR changes that annotation to `@psalm-readonly` which is ignored by default by doctrine/annotations and which does the same thing according to the [psalm documentation](https://psalm.dev/docs/annotating_code/supported_annotations/#psalm-readonly-and-readonly).

My current workaround is to globally ignore the `@readonly` annotation in my Symfony project but I think changing it here would save other people some headache.

I've made a small project to reproduce this issue here: https://github.com/kevinreniers/spatie-enum-jms-serializer. You can trigger the error by running `APP_ENV=prod php bin/console cache:warmup`.

This results in the following error:

```
 // Warming up the cache for the prod environment with debug false                                                      

16:37:29 CRITICAL  [console] Error thrown while running command "cache:warmup". Message: "[Semantical Error] The annotation "@readonly" in property Spatie\Enum\Enum::$value was never imported. Did you maybe forget to add a "use" statement for this annotation?" ["exception" => Doctrine\Common\Annotations\AnnotationException^ { …},"command" => "cache:warmup","message" => "[Semantical Error] The annotation "@readonly" in property Spatie\Enum\Enum::$value was never imported. Did you maybe forget to add a "use" statement for this annotation?"]

In AnnotationException.php line 39:
                                                                                                                                                          
  [Semantical Error] The annotation "@readonly" in property Spatie\Enum\Enum::$value was never imported. Did you maybe forget to add a "use" statement f  
  or this annotation?                                                                                                                                     
                                                                                                                                                          

cache:warmup [--no-optional-warmers]
```