### PR TITLE
Implement flyweight pattern

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -101,6 +101,12 @@ abstract class Enum implements JsonSerializable
      */
     final public static function from($value): Enum
     {
+        if (! (is_string($value) || is_int($value))) {
+            $enumClass = static::class;
+
+            throw new TypeError("Only string and integer are allowed values for enum {$enumClass}.");
+        }
+
         if (!isset(self::$instances[static::class][$value])) {
             self::$instances[static::class][$value] = new static($value);
         }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -34,12 +34,18 @@ abstract class Enum implements JsonSerializable
     private static array $definitionCache = [];
 
     /**
+     * This holds references to all enums created, at most 1 enum per class / value combination is created
+     * @psalm-var array<class-string, <int|string, Enum>>
+     */
+    private static array $instances = [];
+
+    /**
      * @return static[]
      */
     public static function cases(): array
     {
         $instances = array_map(
-            fn (EnumDefinition $definition): Enum => static::make($definition->value),
+            fn (EnumDefinition $definition): Enum => static::from($definition->value),
             static::resolveDefinition()
         );
 
@@ -81,10 +87,38 @@ abstract class Enum implements JsonSerializable
      * @param string|int $value
      *
      * @return static
+     * @deprecated Use `from()` instead
      */
     public static function make($value): Enum
     {
-        return new static($value);
+        return static::from($value);
+    }
+
+    /**
+     * @param string|int $value
+     *
+     * @return static
+     */
+    final public static function from($value): Enum
+    {
+        if (!isset(self::$instances[static::class][$value])) {
+            self::$instances[static::class][$value] = new static($value);
+        }
+        return self::$instances[static::class][$value];
+    }
+
+    /**
+     * @param string|int $value
+     *
+     * @return static
+     */
+    final public static function tryFrom($value): ?Enum
+    {
+        try {
+            return static::from($value);
+        } catch (BadMethodCallException $dummy) {
+            return null;
+        }
     }
 
     /**

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -25,6 +25,12 @@ class EnumTest extends TestCase
     }
 
     /** @test */
+    public function enum_can_be_strict_compared()
+    {
+        $this->assertSame(MyEnum::A(), MyEnum::A());
+    }
+
+    /** @test */
     public function unknown_enum_method_triggers_exception()
     {
         $this->expectException(BadMethodCallException::class);


### PR DESCRIPTION
This PR implements #93, it also adds the PHP8.1 functions `from()` and `tryFrom()`.

I have chosen to mark `make()` as deprecated, but not remove it.
Also since the constructor is marked as `@internal` one could argue that making it private is not a BC break, the fact that the constructor is used in the docs means code consumers will likely be using it in their code.

Needless to say anyone using the constructor directly will not be able to strictly compare instances.