### PR TITLE
Catch TypeError in tryFrom

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -124,6 +124,8 @@ abstract class Enum implements JsonSerializable
             return static::from($value);
         } catch (BadMethodCallException $dummy) {
             return null;
+        } catch (TypeError $dummy) {
+            return null;
         }
     }
 


### PR DESCRIPTION
I'm not sure if this is not put intentionally or it's a bug. 

But using `tryFrom` gives the programmer safety feel to call it especially with `null` values until you get an exception, read the code and realize you need to add extra try or condition into your code.