### PR TITLE
Add label check to equals method.

### DIFF
--- a/src/EnumDefinition.php
+++ b/src/EnumDefinition.php
@@ -39,6 +39,10 @@ class EnumDefinition
             return true;
         }
 
+        if ($this->label === $input) {
+            return true;
+        }
+
         if (is_string($input) && $this->methodName === strtolower($input)) {
             return true;
         }


### PR DESCRIPTION
This is a difficult one to explain so I'll do my best. I also don't think it's really an "issue" as it is more of an I'd like to name my methods this way. Anyways, while working on an API I found an issue with naming methods with multiple words in the style of a constant. For example the issue between `ONEWORD` and `TWO_WORDS` as names for the methods. Take the following classes for example (using laravel) to recreate the issue (enum class and a model). They enum class is set up this way because I'd like to store the integer values into the database and display the labels in the UI, which the docs state that it should not be a problem:

https://github.com/spatie/enum#enum-values

Anyways, here's the example classes:

```
namespace App\Enums;

use Spatie\Enum\Laravel\Enum;

/**
 * @method static self ONEWORD()
 * @method static self TWO_WORDS()
 */
final class TestEnum extends Enum
{
    protected static function values(): array
    {
        return [
            'ONEWORD' => 1,
            'TWO_WORDS' => 2,
        ];
    }

    protected static function labels(): array
    {
        return [
            'ONEWORD' => 'OneWord',
            'TWO_WORDS' => 'Two Words',
        ];
    }
}
```

```
namespace App\Models;

use App\Enums\TestEnum;
use Illuminate\Database\Eloquent\Model;

class TestModel extends Model
{
    protected $casts = [
        'oneword' => TestEnum::class.':nullable',
        'two_words' => TestEnum::class.':nullable',
    ];
}
```

And here's a test route to try out the example:

```
Route::get('/test', function () {
    $testModel = new \App\Models\TestModel();
    $testModel->oneword = 'OneWord';
    // $testModel->two_words = 'Two Words';
    ddd($testModel->getAttributes());
});
```

If I run that route as is I get what I'd expect. Notice the "two_words" line is commented out and the "oneword" works just fine:

```
array:1 [▼
  "oneword" => 1
]
```

So now if I uncomment that "two_words" line I then get the following error:

> BadMethodCallException
> There's no value Two Words defined for enum App\Enums\TestEnum, consider adding it in the docblock definition. 

The stacktrace brought me to the Enum.php file which calls a method "findDefinition" and then that method calls an "equals" method within the "EnumDefinition" class. 

![image](https://user-images.githubusercontent.com/18044230/137576897-21bde631-de42-4abc-b509-c6e2133a7964.png)

So now I set up my example like so just to focus on the "two_words" line where the problem was at:

```
Route::get('/test', function () {
    $testModel = new \App\Models\TestModel();
    // $testModel->oneword = 'OneWord';
    $testModel->two_words = 'Two Words';
    ddd($testModel->getAttributes());
});
```

On to debugging and dumping output.. 

The first condition in the "equals" method compares the enum value to the input value and since I've set up the enum class to use integers as values that condition just won't work in this case. 

> 1 === "Two Words"

Ok so onto the next condition with the method name campared to the input and the dump showed:

> "oneword" === "two words"

That one surprised me a bit. 🤔 So I went back to the TestEnum class and rearranged the docblock by moving the TWO_WORDS method before the ONEWORD method like so:

```
/**
 * @method static self TWO_WORDS()
 * @method static self ONEWORD()
 */
```

Ran the route again and got what was more expected:

> "two_words" === "two words"

Closer! But still no match. What needed to happen with the way my enum class is set up is the "label" needed to be compared to the "$input". So I added a condition for that right after the value condition and then everything seemed to be working as expected again (this PR's commit shows that update). Ran the route and got the following:

```
array:1 [▼
  "two_words" => 2
]
```

Uncommented both the "oneword" and the "two_words" lines in the test route, swapped back the docblock method arrangment to "TWO_WORDS" after "ONEWORD" and got the following:

```
array:2 [▼
  "oneword" => 1
  "two_words" => 2
]
```

So this PR seems to fix my issue and am hoping this can be considered so that method naming like "TWO_WORDS" will be allowed instead of having to use "TWOWORDS" which makes it just a little less readable. Also, since I was working on an API, my enum values are forced to have no spaces as well like so "TwoWords" which is also not ideal.

Terribly sorry for the lengthy write up.. Thank you!