### PR TITLE
Add isset() support for label and value

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -181,6 +181,15 @@ abstract class Enum implements JsonSerializable
     }
 
     /**
+     * @param $name
+     *
+     * @return bool
+     */
+    public function __isset($name){
+        return $name === 'label' || $name === 'value';
+    }
+
+    /**
      * @param string $name
      * @param array $arguments
      *

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -181,7 +181,7 @@ abstract class Enum implements JsonSerializable
     }
 
     /**
-     * @param $name
+     * @param string $name
      *
      * @return bool
      */

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -185,7 +185,8 @@ abstract class Enum implements JsonSerializable
      *
      * @return bool
      */
-    public function __isset($name){
+    public function __isset(string $name): bool
+    {
         return $name === 'label' || $name === 'value';
     }
 


### PR DESCRIPTION
As both `label` and `value` properties can currently be accessed through the magic getter, isset will return false if you try to check for them. 

This PR adds a simple __isset() method that returns true for `label` and `value` properties. I feel like this is probably not used much and thus not noticed so far, but having isset working would be expected behavior for me.