### PR TITLE
Match JsonSerializable interface return type to support PHP 8.1

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -316,7 +316,7 @@ abstract class Enum implements JsonSerializable
     /**
      * @return int|string
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->value;
     }


### PR DESCRIPTION
Using Enums in PHP 8.1 throws a fatal error. There is an open PR for supporting 8.1 (#96), but it doesn't support older PHP versions anymore. This would help in the upgrade path to PHP 8.1.

```
During inheritance of JsonSerializable: Uncaught Whoops\Exception\ErrorException:
    Return type of Spatie\Enum\Enum::jsonSerialize() should either be compatible with
    JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should
    be used to temporarily suppress the notice in <redacated>/vendor/spatie/enum/src/Enum.php:319
```

Package version: `3.10.0`
PHP version: `8.1.0RC5-dev`