### PR TITLE
Implement Stringable interface on Enum

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["8.1", "8.0", "7.4"]
+        php: ["8.1", "8.0"]
         dependency-version: ["prefer-lowest", "prefer-stable"]
         os: ["ubuntu-latest", "windows-latest"]
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*"
     },
     "require-dev": {

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -10,6 +10,7 @@ use Spatie\Enum\Exceptions\DuplicateLabelsException;
 use Spatie\Enum\Exceptions\DuplicateValuesException;
 use Spatie\Enum\Exceptions\UnknownEnumMethod;
 use Spatie\Enum\Exceptions\UnknownEnumProperty;
+use Stringable;
 use TypeError;
 
 /**
@@ -19,7 +20,7 @@ use TypeError;
  *
  * @psalm-consistent-constructor
  */
-abstract class Enum implements JsonSerializable
+abstract class Enum implements JsonSerializable, Stringable
 {
     /**
      * @var string|int


### PR DESCRIPTION
Enum class has a __toString, so it would be great to implements the new Stringable interface.

As the interface is not available for php < 8, I've had the symfony/polyfill-php-80.
