### PR TITLE
Add PHP 8.2 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["8.1", "8.0"]
+        php: [8.2, 8.1, 8.0]
         dependency-version: ["prefer-lowest", "prefer-stable"]
         os: ["ubuntu-latest", "windows-latest"]
 


### PR DESCRIPTION
This PR adds PHP 8.2 to the tests workflow.


_id:php82-support/v1_